### PR TITLE
fix: close MeshStore SQLite handle on stop (Windows file-lock)

### DIFF
--- a/handoff/mesh_broker.py
+++ b/handoff/mesh_broker.py
@@ -137,6 +137,21 @@ class MeshStore:
         return [{"id": r[0], "ref": r[1], "ok": bool(r[2]), "text": r[3], "created": r[4]}
                 for r in rows]
 
+    def close(self) -> None:
+        """Release the SQLite handle. Required for clean shutdown — on Windows an open
+        WAL/connection keeps the db file locked and prevents temp-dir cleanup."""
+        with self._lock:
+            try:
+                self._db.close()
+            except sqlite3.Error:
+                pass
+
+    def __enter__(self) -> "MeshStore":
+        return self
+
+    def __exit__(self, *exc) -> None:
+        self.close()
+
     def mark_delivered(self, ids: list[str], to_did: str) -> None:
         """Mark results as delivered (don't delete; keep them for desktop console viewing), **bound to
         owner to_did**: a paired node cannot ack/mark someone else's results. After poll these are no
@@ -384,6 +399,10 @@ class MeshBroker:
 
     def stop(self):
         self._running = False
+        try:
+            self.store.close()
+        except Exception:  # noqa: BLE001
+            pass
         if self._zc is not None:
             try:
                 self._zc.unregister_service(self._zc_info)

--- a/handoff/tests/test_mesh_broker.py
+++ b/handoff/tests/test_mesh_broker.py
@@ -214,13 +214,13 @@ def test_ack_bound_to_owner():
 def test_requeue_running_on_restart():
     """Startup requeue: tasks stuck in running are restored to pending."""
     with tempfile.TemporaryDirectory() as tmp:
-        store = mb.MeshStore(os.path.join(tmp, "q.db"))
-        store.add_task("t1", "didX", "p")
-        store.claim_next_task()  # → running
-        n = store.requeue_running()
-        assert n == 1, n
-        again = store.claim_next_task()  # should be claimable again
-        assert again and again["id"] == "t1", again
+        with mb.MeshStore(os.path.join(tmp, "q.db")) as store:
+            store.add_task("t1", "didX", "p")
+            store.claim_next_task()  # → running
+            n = store.requeue_running()
+            assert n == 1, n
+            again = store.claim_next_task()  # should be claimable again
+            assert again and again["id"] == "t1", again
         print("✓ test_requeue_running_on_restart")
 
 


### PR DESCRIPTION
## What
The mesh broker never released its SQLite connection, so on Windows the open WAL/connection kept `queue.db` locked — blocking temp-dir cleanup (PermissionError: [WinError 32]) and leaving the file handle open after shutdown.

## Change
- `MeshStore.close()` + context-manager (`__enter__`/`__exit__`) to release the handle
- `MeshBroker.stop()` now calls `store.close()`
- `test_requeue_running_on_restart` uses the context manager so the raw store is closed (suite passes cleanly on Windows)

## Verification
- Full `tests/test_mesh_broker.py`: 9/9 pass (exit 0)
- Broker starts, binds the LAN IP + fixed port 51379, serves; `test_unpaired_rejected` etc. green
- Ad-hoc CM/close checks confirm the temp dir is deletable after stop on Windows